### PR TITLE
add SyllableTokenizer import to SyllableTokenizer docstring

### DIFF
--- a/nltk/tokenize/sonority_sequencing.py
+++ b/nltk/tokenize/sonority_sequencing.py
@@ -44,6 +44,7 @@ class SyllableTokenizer(TokenizerI):
     """
     Syllabifies words based on the Sonority Sequencing Principle (SSP).
 
+        >>> from nltk.tokenize import SyllableTokenizer
         >>> from nltk import word_tokenize
         >>> SSP = SyllableTokenizer()
         >>> SSP.tokenize('justification')


### PR DESCRIPTION
Minor update to the docstring, to fully execute the example, import the SyllableTokenizer as well.